### PR TITLE
Add prefetch option

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,4 +1,4 @@
-{ buildGoApplication, lib, makeWrapper, nix-prefetch-git }:
+{ buildGoApplication, lib, makeWrapper, go, nix-prefetch-git }:
 
 buildGoApplication {
   pname = "gomod2nix";
@@ -14,7 +14,7 @@ buildGoApplication {
   nativeBuildInputs = [ makeWrapper ];
 
   postInstall = ''
-    wrapProgram $out/bin/gomod2nix --prefix PATH : ${lib.makeBinPath [ nix-prefetch-git ]}
+    wrapProgram $out/bin/gomod2nix --prefix PATH : ${lib.makeBinPath [ go nix-prefetch-git ]}
     rm -f $out/bin/builder
   '';
 }

--- a/main.go
+++ b/main.go
@@ -34,8 +34,10 @@ func main() {
 			outDir = directory
 		}
 	} else {
+		moduleVersion := fetch.ModuleVersion(*prefetch)
+
 		if directory == "" {
-			hash := sha1.Sum([]byte(*prefetch))
+			hash := sha1.Sum([]byte(moduleVersion.Path))
 			directory = filepath.Join(os.TempDir(), fmt.Sprintf("gomod2nix.%x", hash))
 		}
 		if outDir == "" {
@@ -47,7 +49,7 @@ func main() {
 			"outDir": outDir,
 		}).Info(fmt.Sprintf("Prefetching '%s'", *prefetch))
 
-		packagePath, err := fetch.FetchRepo(fetch.ModuleVersion(*prefetch), directory)
+		packagePath, err := fetch.FetchRepo(moduleVersion, directory)
 		if err != nil {
 			panic(err)
 		}


### PR DESCRIPTION
Fixes #5 

Adds the option `-prefetch path[@version]`. When specified, changes the behavior of `gomod2nix` such that:

- `directory` defaults to a temporary directory into which the package repo is cloned. This is named using a hash of the package path, so subsequent calls to `gomod2nix` may pull changes instead of cloning a fresh copy.
- `outDir` defaults to the current directory.
- Before resolving modules, fetch the package repo into `directory`.
- If the clone is missing `go.sum`, run `go mod tidy` to generate one.
- Resolve dependency metadata as usual for the cloned repository.