### PR TITLE
builder: Use stdenv from arguments, not go.stdenv

### DIFF
--- a/builder/default.nix
+++ b/builder/default.nix
@@ -79,7 +79,7 @@ let
 
       removeReferences = [ ] ++ lib.optional (!allowGoReference) go;
 
-      package = go.stdenv.mkDerivation (attrs // {
+      package = stdenv.mkDerivation (attrs // {
         nativeBuildInputs = [ removeReferencesTo go ] ++ nativeBuildInputs;
 
         inherit (go) GOOS GOARCH;


### PR DESCRIPTION
It allows users to override the builder to use for example `pkgsStatic.stdenv`.