### PR TITLE
Fix replace directive mapping in fetch.go

### DIFF
--- a/fetch/fetch.go
+++ b/fetch/fetch.go
@@ -78,7 +78,7 @@ func FetchPackages(goModPath string, goSumPath string, goMod2NixPath string, dep
 	// Map repos -> replacement repo
 	replace := make(map[string]string)
 	for _, repl := range mod.Replace {
-		replace[repl.New.Path] = repl.Old.Path
+		replace[repl.Old.Path] = repl.New.Path
 	}
 
 	log.WithFields(log.Fields{


### PR DESCRIPTION
The replace directive mapping was in the wrong direction, causing any replace directive to be ignored when the replace mapping is looked up later on.