### PR TITLE
Lower the prerequisite of gomod2nix

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,8 +1,5 @@
-{ buildGoApplication, go_1_18, nix, lib, makeWrapper, nix-prefetch-git }:
+{ buildGoApplication, go, nix, lib, makeWrapper, nix-prefetch-git }:
 
-let
-  go = go_1_18;
-in
 buildGoApplication {
   inherit go;
   pname = "gomod2nix";


### PR DESCRIPTION
`go_1_18` is only available in nixpkgs master, but `go_1_17` is available in stable `release-21.11`.

It seems even on nixpkgs master, go 1.18 still have some issue on mac: https://github.com/NixOS/nixpkgs/issues/168984, which also happens on our project, while 1.17 is fine.