### PR TITLE
Reintroduce the max workers flag

### DIFF
--- a/lib/executor.go
+++ b/lib/executor.go
@@ -9,17 +9,19 @@ type ParallellExecutor struct {
 	errChan chan error
 	wg      *sync.WaitGroup
 	mux     *sync.Mutex
+	guard   chan struct{}
 
 	// Error returned by Wait(), cached for other Wait() invocations
 	err  error
 	done bool
 }
 
-func NewParallellExecutor() *ParallellExecutor {
+func NewParallellExecutor(maxWorkers int) *ParallellExecutor {
 	return &ParallellExecutor{
 		errChan: make(chan error),
 		mux:     new(sync.Mutex),
 		wg:      new(sync.WaitGroup),
+		guard:   make(chan struct{}, maxWorkers),
 
 		err:  nil,
 		done: false,
@@ -29,8 +31,13 @@ func NewParallellExecutor() *ParallellExecutor {
 func (e *ParallellExecutor) Add(fn func() error) {
 	e.wg.Add(1)
 
+	e.guard <- struct{}{} // Block until a worker is available
+
 	go func() {
 		defer e.wg.Done()
+		defer func() {
+			<-e.guard
+		}()
 
 		err := fn()
 		if err != nil {

--- a/main.go
+++ b/main.go
@@ -13,6 +13,7 @@ import (
 func main() {
 
 	var directory = flag.String("dir", "./", "Go project directory")
+	var maxJobs = flag.Int("jobs", 10, "Number of max parallel jobs")
 	var outDirFlag = flag.String("outdir", "", "output directory (if different from project directory)")
 	flag.Parse()
 
@@ -23,7 +24,7 @@ func main() {
 
 	goMod2NixPath := filepath.Join(outDir, "gomod2nix.toml")
 	outFile := goMod2NixPath
-	pkgs, err := generate.GeneratePkgs(*directory, goMod2NixPath)
+	pkgs, err := generate.GeneratePkgs(*directory, goMod2NixPath, *maxJobs)
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
It turns out that this is actually useful to limit the number of open files.

Fixes https://github.com/tweag/gomod2nix/issues/50.