### PR TITLE
Build non-development packages in the same way as development packages

### DIFF
--- a/builder/symlink/symlink.go
+++ b/builder/symlink/symlink.go
@@ -16,37 +16,40 @@ type Package struct {
 	ReplacedPath  string `json:"replaced,omitempty"`
 }
 
-type Output struct {
-	SchemaVersion int                 `json:"schema"`
-	Mod           map[string]*Package `json:"mod"`
-}
+// type Output struct {
+// 	SchemaVersion int                 `json:"schema"`
+// 	Mod           map[string]*Package `json:"mod"`
+// }
 
 func main() {
 
-	var output Output
+	// var output Output
 	sources := make(map[string]string)
+	pkgs := make(map[string]*Package)
 
-	b, err := ioutil.ReadFile(os.Getenv("sourcesPath"))
-	if err != nil {
-		panic(err)
+	{
+		b, err := ioutil.ReadFile(os.Getenv("sourcesPath"))
+		if err != nil {
+			panic(err)
+		}
+
+		err = json.Unmarshal(b, &sources)
+		if err != nil {
+			panic(err)
+		}
 	}
 
-	err = json.Unmarshal(b, &sources)
-	if err != nil {
-		panic(err)
-	}
+	{
+		b, err := ioutil.ReadFile(os.Getenv("jsonPath"))
+		if err != nil {
+			panic(err)
+		}
 
-	b, err = ioutil.ReadFile(os.Getenv("jsonPath"))
-	if err != nil {
-		panic(err)
+		err = json.Unmarshal(b, &pkgs)
+		if err != nil {
+			panic(err)
+		}
 	}
-
-	err = json.Unmarshal(b, &output)
-	if err != nil {
-		panic(err)
-	}
-
-	pkgs := output.Mod
 
 	keys := make([]string, 0, len(pkgs))
 	for key := range pkgs {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"fmt"
-	"io"
 	"os"
 	"path/filepath"
 
@@ -69,14 +68,14 @@ func generateFunc(cmd *cobra.Command, args []string) {
 		}
 
 		var goPackagePath string
-		var install []string
+		var subPackages []string
 
 		if tmpProj != nil {
-			install = tmpProj.Install
+			subPackages = tmpProj.SubPackages
 			goPackagePath = tmpProj.GoPackagePath
 		}
 
-		output, err := schema.Marshal(pkgs, goPackagePath, install)
+		output, err := schema.Marshal(pkgs, goPackagePath, subPackages)
 		if err != nil {
 			panic(fmt.Errorf("error marshaling output: %v", err))
 		}
@@ -86,28 +85,6 @@ func generateFunc(cmd *cobra.Command, args []string) {
 			panic(fmt.Errorf("error writing file: %v", err))
 		}
 		log.Info(fmt.Sprintf("Wrote: %s", outFile))
-	}
-
-	// If we are dealing with a project packaged by passing packages on the command line, copy go.mod
-	if tmpProj != nil {
-		outMod := filepath.Join(outDir, "go.mod")
-
-		fin, err := os.Open(filepath.Join(tmpProj.Dir, "go.mod"))
-		if err != nil {
-			panic(fmt.Errorf("error opening go.mod: %v", err))
-		}
-
-		fout, err := os.Create(outMod)
-		if err != nil {
-			panic(fmt.Errorf("error creating go.mod: %v", err))
-		}
-
-		_, err = io.Copy(fout, fin)
-		if err != nil {
-			panic(fmt.Errorf("error writing go.mod: %v", err))
-		}
-
-		log.Info(fmt.Sprintf("Wrote: %s", outMod))
 	}
 }
 

--- a/gomod2nix.toml
+++ b/gomod2nix.toml
@@ -1,4 +1,4 @@
-schema = 2
+schema = 3
 
 [mod]
   [mod."cloud.google.com/go"]

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -6,7 +6,7 @@ import (
 	"os"
 )
 
-const SchemaVersion = 2
+const SchemaVersion = 3
 
 type Package struct {
 	GoPackagePath string `toml:"-"`
@@ -20,17 +20,17 @@ type Output struct {
 	Mod           map[string]*Package `toml:"mod"`
 
 	// Packages with passed import paths trigger `go install` based on this list
-	Install []string `toml:"install,omitempty"`
+	SubPackages []string `toml:"subPackages,omitempty"`
 
 	// Packages with passed import paths has a "default package" which pname & version is inherit from
 	GoPackagePath string `toml:"goPackagePath,omitempty"`
 }
 
-func Marshal(pkgs []*Package, goPackagePath string, install []string) ([]byte, error) {
+func Marshal(pkgs []*Package, goPackagePath string, subPackages []string) ([]byte, error) {
 	out := &Output{
 		SchemaVersion: SchemaVersion,
 		Mod:           make(map[string]*Package),
-		Install:       install,
+		SubPackages:   subPackages,
 		GoPackagePath: goPackagePath,
 	}
 


### PR DESCRIPTION
The difference in behaviour was unfortunate.

The only downside I can see is that this doesn't allow for mixed
origins in the same package, which probably shouldn't be done anyway.