### PR TITLE
Fix Go compiler missing from mkGoEnv created environments

### DIFF
--- a/builder/default.nix
+++ b/builder/default.nix
@@ -170,7 +170,7 @@ let
       dontConfigure = true;
       dontInstall = true;
 
-      propagatedNativeBuildInputs = [ go ];
+      propagatedBuildInputs = [ go ];
 
       GO_NO_VENDOR_CHECKS = "1";
 

--- a/shell.nix
+++ b/shell.nix
@@ -12,10 +12,10 @@
 
 pkgs.mkShell {
   NIX_PATH = "nixpkgs=${builtins.toString pkgs.path}";
-  buildInputs = [
+  nativeBuildInputs = [
     pkgs.nixpkgs-fmt
-    pkgs.gomod2nix.go
-    pkgs.gomod2nix
     pkgs.golangci-lint
+    pkgs.gomod2nix
+    (pkgs.mkGoEnv { pwd = ./.; })
   ];
 }

--- a/tests/mkgoenv/default.nix
+++ b/tests/mkgoenv/default.nix
@@ -1,15 +1,21 @@
-{ runCommand, mkGoEnv }:
+{ runCommand, mkGoEnv, which }:
 
 let
   env = mkGoEnv {
     pwd = ./.;
   };
 in
-runCommand "mkgoenv-assert" { } ''
+runCommand "mkgoenv-assert"
+{
+  nativeBuildInputs = [ which ];
+  buildInputs = [ env ]; # Trigger propagation
+} ''
   if ! test -f ${env}/bin/stringer; then
     echo "stringer command not found in env!"
     exit 1
   fi
+
+  which go > /dev/null || echo "Go compiler not found in env!"
 
   ln -s ${env} $out
 ''


### PR DESCRIPTION
And use `mkGoEnv` in `shell.nix` so that we dogfood it.

Closes #68