### PR TITLE
Refactor to generic builder expression

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,8 +1,5 @@
-{ stdenv, buildGoApplication, go, nix, lib, makeWrapper, installShellFiles }:
-
-buildGoApplication {
-  inherit go;
-  pname = "gomod2nix";
+{ lib }:
+(import ./generic.nix {
   version = "1.0.0";
   src = lib.cleanSourceWith {
     filter = name: type: builtins.foldl' (v: s: v && ! lib.hasSuffix s name) true [
@@ -13,26 +10,4 @@ buildGoApplication {
     src = lib.cleanSource ./.;
   };
   modules = ./gomod2nix.toml;
-
-  allowGoReference = true;
-
-  subPackages = [ "." ];
-
-  nativeBuildInputs = [ makeWrapper installShellFiles ];
-
-  postInstall = lib.optionalString (stdenv.buildPlatform == stdenv.targetPlatform) ''
-    $out/bin/gomod2nix completion bash > gomod2nix.bash
-    $out/bin/gomod2nix completion fish > gomod2nix.fish
-    $out/bin/gomod2nix completion zsh > _gomod2nix
-    installShellCompletion gomod2nix.{bash,fish} _gomod2nix
-  '' + ''
-    wrapProgram $out/bin/gomod2nix --prefix PATH : ${lib.makeBinPath [ go ]}
-  '';
-
-  meta = {
-    description = "Convert applications using Go modules -> Nix";
-    homepage = "https://github.com/tweag/gomod2nix";
-    license = lib.licenses.mit;
-    maintainers = [ lib.maintainers.adisbladis ];
-  };
-}
+})

--- a/flake.nix
+++ b/flake.nix
@@ -29,7 +29,7 @@
           };
         in
         {
-          packages.default = pkgs.callPackage ./default.nix { };
+          packages.default = pkgs.callPackage (pkgs.callPackage ./default.nix { }) { };
           devShells.default = import ./shell.nix { inherit pkgs; };
         })
     );

--- a/generic.nix
+++ b/generic.nix
@@ -1,0 +1,45 @@
+{ version
+, src
+, modules
+}:
+{ stdenv
+, callPackage
+, go
+, lib
+, makeWrapper
+, installShellFiles
+, fetchFromGitHub
+}:
+
+let
+  builder = callPackage ./builder { };
+
+in
+builder.buildGoApplication {
+  pname = "gomod2nix";
+  inherit version modules src go;
+
+  allowGoReference = true;
+
+  subPackages = [ "." ];
+
+  nativeBuildInputs = [ makeWrapper installShellFiles ];
+
+  passthru = builder;
+
+  postInstall = lib.optionalString (stdenv.buildPlatform == stdenv.targetPlatform) ''
+    $out/bin/gomod2nix completion bash > gomod2nix.bash
+    $out/bin/gomod2nix completion fish > gomod2nix.fish
+    $out/bin/gomod2nix completion zsh > _gomod2nix
+    installShellCompletion gomod2nix.{bash,fish} _gomod2nix
+  '' + ''
+    wrapProgram $out/bin/gomod2nix --prefix PATH : ${lib.makeBinPath [ go ]}
+  '';
+
+  meta = {
+    description = "Convert applications using Go modules -> Nix";
+    homepage = "https://github.com/tweag/gomod2nix";
+    license = lib.licenses.mit;
+    maintainers = [ lib.maintainers.adisbladis ];
+  };
+}

--- a/overlay.nix
+++ b/overlay.nix
@@ -1,4 +1,8 @@
-final: prev: {
-  inherit (final.darwin.apple_sdk_11_0.callPackage ./builder { }) buildGoApplication mkGoEnv;
-  gomod2nix = final.darwin.apple_sdk_11_0.callPackage ./default.nix { };
+final: prev:
+let
+  callPackage = final.darwin.apple_sdk_11_0.callPackage;
+in
+{
+  inherit (callPackage ./builder { }) buildGoApplication mkGoEnv;
+  gomod2nix = callPackage (callPackage ./default.nix { }) { };
 }


### PR DESCRIPTION
This will make nixpkgs dumps (ie dumping gomod2nix into nixpkgs) easier going forward.