### PR TITLE
Copy vendor directory instead of symlinking to them

### DIFF
--- a/builder/default.nix
+++ b/builder/default.nix
@@ -193,7 +193,7 @@ let
         cp ${pwd + "/go.sum"} source/go.sum
         cp ${pwd + "/tools.go"} source/tools.go
         cd source
-        ln -s ${vendorEnv} vendor
+        cp -r ${vendorEnv} vendor
 
         ${internal.install}
       '';
@@ -266,7 +266,7 @@ let
           cd "$modRoot"
           if [ -n "${vendorEnv}" ]; then
               rm -rf vendor
-              ln -s ${vendorEnv} vendor
+              cp -r ${vendorEnv} vendor
           fi
 
           runHook postConfigure


### PR DESCRIPTION
As pointed out in
https://github.com/NixOS/nixpkgs/pull/188035#discussion_r953044264
this can be a source of errors when builders do things they shouldn't.

I'm not really happy about this change as it causes quite a bit more
IO for larger dependency graphs.