### PR TITLE
Run unit tests under subdirs

### DIFF
--- a/builder/default.nix
+++ b/builder/default.nix
@@ -285,12 +285,22 @@ let
           exclude+='\)'
 
           buildGoDir() {
-            local d; local cmd;
-            cmd="$1"
-            d="$2"
+            local cmd="$1" dir="$2"
+
             . $TMPDIR/buildFlagsArray
+
+            declare -a flags
+            flags+=($buildFlags "''${buildFlagsArray[@]}")
+            flags+=(''${tags:+-tags=${lib.concatStringsSep "," tags}})
+            flags+=(''${ldflags:+-ldflags="$ldflags"})
+            flags+=("-v" "-p" "$NIX_BUILD_CORES")
+
+            if [ "$cmd" = "test" ]; then
+              flags+=($checkFlags)
+            fi
+
             local OUT
-            if ! OUT="$(go $cmd $buildFlags "''${buildFlagsArray[@]}" ''${tags:+-tags=${concatStringsSep "," tags}} ''${ldflags:+-ldflags="$ldflags"} -v -p $NIX_BUILD_CORES $d 2>&1)"; then
+            if ! OUT="$(go $cmd "''${flags[@]}" $dir 2>&1)"; then
               if echo "$OUT" | grep -qE 'imports .*?: no Go files in'; then
                 echo "$OUT" >&2
                 return 1
@@ -352,7 +362,7 @@ let
           runHook preCheck
 
           for pkg in $(getGoDirs test); do
-            buildGoDir test $checkFlags "$pkg"
+            buildGoDir test "$pkg"
           done
 
           runHook postCheck


### PR DESCRIPTION
Bug:
Due to the way `buildGoDir` function was repurposed to also run `go
test`, if `checkFlags` was defined, `go test` was ran only at the top
level directory. Only the first element of `checkFlags` array would get
passed to the `go test` command as arguments.

Fix:
Now the first parameter to `buildGoDir` is handled as the command.  If
the command is "test" `checkFlags` get passed as arguments along with
other build flags like ldflags, tags, etc.

Readability:
- Iteratively build a flag array in `buildGoDir` instead of single long
  variable expansion command line.
- Bash style: Single line local assignment of positional parameters.

This is a port of https://github.com/NixOS/nixpkgs/pull/173702/commits/89864413b28a787ee61e46a7ff510587eb041e32.