### PR TITLE
fix: include `mkVendorEnv` in attrset

### DIFF
--- a/builder/default.nix
+++ b/builder/default.nix
@@ -500,5 +500,5 @@ let
 
 in
 {
-  inherit buildGoApplication mkGoEnv;
+  inherit buildGoApplication mkGoEnv mkVendorEnv;
 }


### PR DESCRIPTION
`mkVendorEnv` was exposed in #116, but since `mkVendorEnv` was not included in the attrset returned by `builder/default.nix` accessing it results in an error: `error: attribute 'mkVendorEnv' missing`.