### PR TITLE
Fix/private dependencies managment

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,28 @@ in pkgs.buildGoApplication {
 
 For more in-depth usage check the [Getting Started](./docs/getting-started.md) and the [Nix API reference](./docs/nix-reference.md) docs.
 
+### Private repositories
+
+Gomod2nix supports private Go module repositories. Use the `--private` flag to generate hashes for private repos:
+
+``` bash
+$ gomod2nix generate --private=github.com/myorg,git.company.com
+```
+
+Then specify `privateRepoPrefixes` in your Nix configuration:
+
+``` nix
+pkgs.buildGoApplication {
+  pname = "myapp";
+  version = "0.1";
+  src = ./.;
+  modules = ./gomod2nix.toml;
+  privateRepoPrefixes = [ "github.com/myorg" ];
+}
+```
+
+See [Working with private repositories](./docs/getting-started.md#working-with-private-repositories) for details.
+
 ## Motivation
 
 The [announcement blog post](https://www.tweag.io/blog/2021-03-04-gomod2nix/) contains comparisons with other Go build systems for Nix and additional notes on the design choices made.

--- a/builder/default.nix
+++ b/builder/default.nix
@@ -67,27 +67,50 @@ let
   # Convert module path to a valid derivation name
   sanitizeName = path: builtins.replaceStrings [ "/" "." "@" ] [ "-" "-" "-" ] path;
 
-  # Fetch a Go module, optionally using a pre-fetched source from the sources attrset.
-  # The sources parameter allows overriding module fetching for private dependencies
-  # that cannot be fetched via the Go module proxy.
+  # Fetch a Go module.
+  #
+  # Supports multiple fetch strategies (in order of priority):
+  # 1. Manual sources override via 'sources' parameter
+  # 2. Git fetch for private repos with pre-computed hashes (gitHash/gitRev)
+  # 3. Standard Go module proxy fetch
   fetchGoModule =
     {
       hash,
       goPackagePath,
       version,
       go,
+      # Manual source overrides. Key format: "${goPackagePath}@${version}"
       sources ? { },
+      # Module prefixes to fetch via git instead of Go proxy
+      privateRepoPrefixes ? [ ],
+      # Git-specific hash and rev (from gomod2nix generate --private)
+      gitHash ? null,
+      gitRev ? null,
     }:
     let
-      # Key format: "${goPackagePath}@${version}"
-      # Using the full module path avoids collisions between modules with the same
-      # base name (e.g., "github.com/foo/bar/v2@v2.0.0" vs "github.com/baz/bar/v2@v2.0.0")
       sourceKey = "${goPackagePath}@${version}";
-    in
-    if hasAttr sourceKey sources then
-      sources.${sourceKey}
-    else
-      stdenvNoCC.mkDerivation {
+      isPrivateRepo = builtins.any (prefix: lib.hasPrefix prefix goPackagePath) privateRepoPrefixes;
+      hasGitInfo = gitHash != null && gitRev != null;
+
+      # Convert Go module path to SSH git URL
+      pathParts = lib.splitString "/" goPackagePath;
+      host = builtins.elemAt pathParts 0;
+      pathWithoutVersion = lib.concatStringsSep "/" (
+        builtins.filter (p: !(lib.hasPrefix "v" p && builtins.match "v[0-9]+" p != null)) (
+          lib.drop 1 pathParts
+        )
+      );
+      gitUrl = "git@${host}:${pathWithoutVersion}.git";
+
+      fetchedPrivateRepo = builtins.fetchGit {
+        url = gitUrl;
+        rev = gitRev;
+        allRefs = true;
+        narHash = gitHash;
+      };
+
+      # Standard fetch via Go module proxy
+      standardFetch = stdenvNoCC.mkDerivation {
         name = "${sanitizeName goPackagePath}_${version}";
         builder = ./fetch.sh;
         inherit goPackagePath version;
@@ -102,6 +125,14 @@ let
         outputHash = hash;
         impureEnvVars = fetchers.proxyImpureEnvVars ++ [ "GOPROXY" ];
       };
+    in
+    if hasAttr sourceKey sources then
+      sources.${sourceKey}
+    else if isPrivateRepo && hasGitInfo then
+      fetchedPrivateRepo
+    else
+      # Fall back to standard fetch (works if GOPROXY is configured for private repos)
+      standardFetch;
 
   mkVendorEnv =
     {
@@ -112,6 +143,7 @@ let
       goMod,
       pwd,
       sources ? { },
+      privateRepoPrefixes ? [ ],
     }:
     let
       localReplaceCommands =
@@ -131,7 +163,10 @@ let
         fetchGoModule {
           goPackagePath = meta.replaced or goPackagePath;
           inherit (meta) version hash;
-          inherit go sources;
+          inherit go sources privateRepoPrefixes;
+          # Pass git-specific fields if present (from gomod2nix generate --private)
+          gitHash = meta.gitHash or null;
+          gitRev = meta.gitRev or null;
         }
       ) modulesStruct.mod;
     in
@@ -221,9 +256,10 @@ let
       pwd,
       toolsGo ? pwd + "/tools.go",
       modules ? pwd + "/gomod2nix.toml",
-      # Pre-fetched sources for private/vendored dependencies that cannot be
-      # fetched via the Go module proxy. Key format: "${goPackagePath}@${version}"
+      # Manual source overrides. Key format: "${goPackagePath}@${version}"
       sources ? { },
+      # Module prefixes to fetch via git instead of Go proxy
+      privateRepoPrefixes ? [ ],
       ...
     }@attrs:
     let
@@ -239,6 +275,7 @@ let
           modulesStruct
           pwd
           sources
+          privateRepoPrefixes
           ;
       };
 
@@ -247,6 +284,7 @@ let
       removeAttrs attrs [
         "pwd"
         "sources"
+        "privateRepoPrefixes"
       ]
       // {
         name = "${baseNameOf goMod.module}-env";
@@ -302,10 +340,10 @@ let
       passthru ? { },
       tags ? [ ],
       ldflags ? [ ],
-      # Pre-fetched sources for private/vendored dependencies that cannot be
-      # fetched via the Go module proxy. Key format: "${goPackagePath}@${version}"
-      # Example: "github.com/myorg/private-lib@v1.2.3" = fetchedSource;
+      # Manual source overrides. Key format: "${goPackagePath}@${version}"
       sources ? { },
+      # Module prefixes to fetch via git instead of Go proxy
+      privateRepoPrefixes ? [ ],
       ...
     }@attrs:
     let
@@ -327,6 +365,7 @@ let
           modulesStruct
           pwd
           sources
+          privateRepoPrefixes
           ;
       };
 
@@ -342,7 +381,10 @@ let
       // optionalAttrs (hasAttr "subPackages" modulesStruct) {
         subPackages = modulesStruct.subPackages;
       }
-      // removeAttrs attrs [ "sources" ]
+      // removeAttrs attrs [
+        "sources"
+        "privateRepoPrefixes"
+      ]
       // {
         nativeBuildInputs = [
           rsync

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -81,3 +81,73 @@ To speed up development and avoid downloading dependencies again in the Nix stor
 ``` bash
 $ gomod2nix import
 ```
+
+## Working with private repositories
+
+Gomod2nix supports private Go module repositories (e.g., private GitHub repos or self-hosted Git servers). This works by using `builtins.fetchGit` with pre-computed hashes, which allows pure Nix evaluation without requiring network access during build time.
+
+### Generating hashes for private repos
+
+Use the `--private` flag to specify prefixes for private repositories. Gomod2nix will clone these repos via SSH and compute their NAR hashes:
+
+``` bash
+$ gomod2nix generate --private=github.com/myorg,git.company.com
+```
+
+You can specify multiple prefixes separated by commas. Any module path starting with these prefixes will be treated as private.
+
+**Requirements:**
+- SSH access to the private repositories (via ssh-agent or SSH keys)
+- Git must be available in your PATH
+
+The generated `gomod2nix.toml` will include additional fields for private repos:
+
+```toml
+[mod."github.com/myorg/private-lib"]
+  version = "v1.2.3"
+  hash = "sha256-..."
+  gitHash = "sha256-..."
+  gitRev = "abc123..."
+```
+
+### Building with private repos
+
+In your Nix configuration, specify which module prefixes are private using `privateRepoPrefixes`:
+
+``` nix
+pkgs.buildGoApplication {
+  pname = "myapp";
+  version = "0.1";
+  pwd = ./.;
+  src = ./.;
+  modules = ./gomod2nix.toml;
+  privateRepoPrefixes = [
+    "github.com/myorg"
+    "git.company.com"
+  ];
+}
+```
+
+At evaluation time, Nix will use `builtins.fetchGit` to fetch these dependencies via SSH, using the pre-computed `gitHash` and `gitRev` from `gomod2nix.toml`.
+
+### Alternative: Using the sources parameter
+
+For more control, you can manually provide sources for specific modules using the `sources` parameter:
+
+``` nix
+pkgs.buildGoApplication {
+  pname = "myapp";
+  version = "0.1";
+  pwd = ./.;
+  src = ./.;
+  modules = ./gomod2nix.toml;
+  sources = {
+    "github.com/myorg/private-lib@v1.2.3" = fetchGit {
+      url = "git@github.com:myorg/private-lib.git";
+      rev = "...";
+    };
+  };
+}
+```
+
+The key format is `"<module-path>@<version>"`.

--- a/docs/nix-reference.md
+++ b/docs/nix-reference.md
@@ -15,6 +15,8 @@ Arguments:
 - **tags** A list of tags to pass the Go compiler during the build (\_default: `[ ]`).
 - **ldflags** A list of `ldflags` to pass the Go compiler during the build (\_default: `[ ]`).
 - **nativeBuildInputs** A list of packages to include in the build derivation (\_default: `[ ]`).
+- **sources** Manual source overrides (\_default: `{ }`). Keys use format `"<module-path>@<version>"`.
+- **privateRepoPrefixes** Module prefixes to fetch via git instead of Go proxy (\_default: `[ ]`).
 
 All other arguments are passed verbatim to `stdenv.mkDerivation`.
 
@@ -25,5 +27,7 @@ Arguments:
 - **pwd** Path to working directory.
 - **modules** Path to `gomod2nix.toml` (\_default: `pwd + "/gomod2nix.toml"`).
 - **toolsGo** Path to `tools.go` (\_default: `pwd + "/tools.go"`).
+- **sources** Manual source overrides (\_default: `{ }`). Keys use format `"<module-path>@<version>"`.
+- **privateRepoPrefixes** Module prefixes to fetch via git instead of Go proxy (\_default: `[ ]`).
 
 All other arguments are passed verbatim to `stdenv.mkDerivation`.

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -15,9 +15,10 @@ import (
 const directoryDefault = "./"
 
 var (
-	flagDirectory string
-	flagOutDir    string
-	maxJobs       int
+	flagDirectory           string
+	flagOutDir              string
+	maxJobs                 int
+	flagPrivateRepoPrefixes []string
 )
 
 func generateFunc(cmd *cobra.Command, args []string) {
@@ -63,7 +64,7 @@ func generateFunc(cmd *cobra.Command, args []string) {
 	{
 		goMod2NixPath := filepath.Join(outDir, "gomod2nix.toml")
 		outFile := goMod2NixPath
-		pkgs, err := generate.GeneratePkgs(directory, goMod2NixPath, maxJobs)
+		pkgs, err := generate.GeneratePkgsWithPrivate(directory, goMod2NixPath, maxJobs, flagPrivateRepoPrefixes)
 		if err != nil {
 			panic(fmt.Errorf("error generating pkgs: %v", err))
 		}
@@ -117,6 +118,7 @@ func init() {
 	rootCmd.PersistentFlags().StringVar(&flagDirectory, "dir", "./", "Go project directory")
 	rootCmd.PersistentFlags().StringVar(&flagOutDir, "outdir", "", "Output directory (defaults to project directory)")
 	rootCmd.PersistentFlags().IntVar(&maxJobs, "jobs", 10, "Max number of concurrent jobs")
+	rootCmd.PersistentFlags().StringSliceVar(&flagPrivateRepoPrefixes, "private", nil, "Private repo prefixes for git hash generation (comma-separated, e.g., 'github.com/myorg,git.company.com')")
 
 	rootCmd.AddCommand(generateCmd)
 	rootCmd.AddCommand(importCmd)

--- a/internal/generate/generate.go
+++ b/internal/generate/generate.go
@@ -152,7 +152,141 @@ builtins.filterSource (name: type: baseNameOf name != ".DS_Store") (
 	return executor.Wait()
 }
 
+// Convert Go module path to git SSH URL
+// e.g., "github.com/org/repo/v2" -> "git@github.com:org/repo.git"
+func modulePathToGitURL(goPackagePath string) string {
+	parts := strings.Split(goPackagePath, "/")
+	if len(parts) < 2 {
+		return ""
+	}
+	host := parts[0]
+
+	// Remove version suffix (e.g., /v2, /v3) from path
+	var pathParts []string
+	for _, p := range parts[1:] {
+		// Skip version directories like v2, v3, etc.
+		if len(p) > 1 && p[0] == 'v' {
+			if _, err := fmt.Sscanf(p, "v%d", new(int)); err == nil {
+				continue
+			}
+		}
+		pathParts = append(pathParts, p)
+	}
+
+	if len(pathParts) < 2 {
+		// Need at least org/repo
+		pathParts = parts[1:]
+	}
+
+	// For most hosts, we need org/repo (first two path components)
+	repoPath := strings.Join(pathParts, "/")
+	if len(pathParts) > 2 {
+		// Take only first two components for the repo path
+		repoPath = strings.Join(pathParts[:2], "/")
+	}
+
+	return fmt.Sprintf("git@%s:%s.git", host, repoPath)
+}
+
+// Extract git revision from version string
+// For pseudo-versions like v0.0.0-20240823115631-b4344a4c2550, extract the commit hash
+func extractGitRev(version string) string {
+	// Pseudo-version format: vX.Y.Z-yyyymmddhhmmss-abcdef123456
+	if strings.HasPrefix(version, "v0.0.0-") || strings.Count(version, "-") >= 2 {
+		parts := strings.Split(version, "-")
+		if len(parts) >= 3 {
+			return parts[len(parts)-1]
+		}
+	}
+	return ""
+}
+
+// Check if version is a pseudo-version (commit-based)
+func isPseudoVersion(version string) bool {
+	return strings.HasPrefix(version, "v0.0.0-") || strings.Count(version, "-") >= 2
+}
+
+// gitFilter filters out .git directory and .DS_Store files from NAR hash computation
+func gitFilter(name string, nodeType nar.NodeType) bool {
+	base := strings.ToLower(filepath.Base(name))
+	// Filter out .git directory and .DS_Store files
+	if base == ".git" || base == ".ds_store" {
+		return false
+	}
+	return true
+}
+
+// fetchGitHash clones a git repo and computes the NAR hash directly
+// This only requires git to be available in the PATH
+func fetchGitHash(gitURL, version string) (hash string, rev string, err error) {
+	// Create a temporary directory for the clone
+	tmpDir, err := os.MkdirTemp("", "gomod2nix-git-*")
+	if err != nil {
+		return "", "", fmt.Errorf("failed to create temp directory: %w", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	cloneDir := filepath.Join(tmpDir, "repo")
+	var stderr bytes.Buffer
+
+	if isPseudoVersion(version) {
+		// For pseudo-versions, extract the commit hash and fetch that specific commit
+		commitHash := extractGitRev(version)
+		if commitHash == "" {
+			return "", "", fmt.Errorf("could not extract commit hash from version %s", version)
+		}
+
+		// Clone the repo (shallow first, then deepen if needed to find the commit)
+		cloneCmd := exec.Command("git", "clone", "--filter=blob:none", gitURL, cloneDir)
+		stderr.Reset()
+		cloneCmd.Stderr = &stderr
+		if err := cloneCmd.Run(); err != nil {
+			return "", "", fmt.Errorf("git clone failed: %w\n%s", err, stderr.String())
+		}
+
+		// Checkout the specific commit (short hash should work now)
+		checkoutCmd := exec.Command("git", "-C", cloneDir, "checkout", commitHash)
+		stderr.Reset()
+		checkoutCmd.Stderr = &stderr
+		if err := checkoutCmd.Run(); err != nil {
+			return "", "", fmt.Errorf("git checkout failed for commit %s: %w\n%s", commitHash, err, stderr.String())
+		}
+
+		rev = commitHash
+	} else {
+		// For regular versions (tags), clone with the specific tag
+		cloneCmd := exec.Command("git", "clone", "--depth", "1", "--branch", version, gitURL, cloneDir)
+		stderr.Reset()
+		cloneCmd.Stderr = &stderr
+		if err := cloneCmd.Run(); err != nil {
+			return "", "", fmt.Errorf("git clone failed for tag %s: %w\n%s", version, err, stderr.String())
+		}
+	}
+
+	// Get the full commit hash (rev)
+	revCmd := exec.Command("git", "-C", cloneDir, "rev-parse", "HEAD")
+	revOutput, err := revCmd.Output()
+	if err != nil {
+		return "", "", fmt.Errorf("failed to get commit hash: %w", err)
+	}
+	rev = strings.TrimSpace(string(revOutput))
+
+	// Compute NAR hash of the checkout (excluding .git directory)
+	h := sha256.New()
+	if err := nar.DumpPathFilter(h, cloneDir, gitFilter); err != nil {
+		return "", "", fmt.Errorf("failed to compute NAR hash: %w", err)
+	}
+	digest := h.Sum(nil)
+	hash = "sha256-" + base64.StdEncoding.EncodeToString(digest)
+
+	return hash, rev, nil
+}
+
 func GeneratePkgs(directory string, goMod2NixPath string, numWorkers int) ([]*schema.Package, error) {
+	return GeneratePkgsWithPrivate(directory, goMod2NixPath, numWorkers, nil)
+}
+
+func GeneratePkgsWithPrivate(directory string, goMod2NixPath string, numWorkers int, privateRepoPrefixes []string) ([]*schema.Package, error) {
 	modDownloads, replace, err := common(directory)
 	if err != nil {
 		return nil, err
@@ -168,6 +302,16 @@ func GeneratePkgs(directory string, goMod2NixPath string, numWorkers int) ([]*sc
 		mux.Lock()
 		packages = append(packages, pkg)
 		mux.Unlock()
+	}
+
+	// Helper to check if path is private
+	isPrivate := func(path string) bool {
+		for _, prefix := range privateRepoPrefixes {
+			if strings.HasPrefix(path, prefix) {
+				return true
+			}
+		}
+		return false
 	}
 
 	for _, dl := range modDownloads {
@@ -201,6 +345,28 @@ func GeneratePkgs(directory string, goMod2NixPath string, numWorkers int) ([]*sc
 			}
 			if hasReplace {
 				pkg.ReplacedPath = dl.Path
+			}
+
+			// For private repos, also calculate git hash
+			if isPrivate(goPackagePath) {
+				gitURL := modulePathToGitURL(goPackagePath)
+				if gitURL != "" {
+					log.WithFields(log.Fields{
+						"goPackagePath": goPackagePath,
+						"gitURL":        gitURL,
+					}).Info("Fetching git hash for private repo")
+
+					gitHash, gitRev, err := fetchGitHash(gitURL, dl.Version)
+					if err != nil {
+						log.WithFields(log.Fields{
+							"goPackagePath": goPackagePath,
+							"error":         err,
+						}).Warn("Failed to fetch git hash, skipping git fields")
+					} else {
+						pkg.GitHash = gitHash
+						pkg.GitRev = gitRev
+					}
+				}
 			}
 
 			addPkg(pkg)

--- a/internal/schema/schema.go
+++ b/internal/schema/schema.go
@@ -15,6 +15,9 @@ type Package struct {
 	Version       string `toml:"version"`
 	Hash          string `toml:"hash"`
 	ReplacedPath  string `toml:"replaced,omitempty"`
+	// Git-specific fields for private repos (fetched via builtins.fetchGit)
+	GitHash string `toml:"gitHash,omitempty"` // NAR hash of git checkout
+	GitRev  string `toml:"gitRev,omitempty"`  // Git commit revision
 }
 
 type Output struct {


### PR DESCRIPTION
Add support for building Go applications with private module dependencies
without requiring --impure flag.

Changes:
- Skip failing sources with warning messages
- prefetch sources injected with sources parameter 
- Add --private flag to `gomod2nix generate` for specifying private repo prefixes
- Compute git NAR hashes by cloning repos and hashing content directly
- Add privateRepoPrefixes parameter to buildGoApplication for automatic
  private repo fetching via builtins.fetchGit
- Add sources parameter to buildGoApplication for manual source overrides
  using key format "<module-path>@<version>"
- Update gomod2nix.toml schema with gitHash and gitRev fields
- Gracefully skip private repos during `gomod2nix import` instead of failing

Usage:
  gomod2nix generate --private=github.com/myorg,git.company.com

  buildGoApplication {
    pname = "myapp";
    src = ./.;
    modules = ./gomod2nix.toml;
    privateRepoPrefixes = [ "github.com/myorg" ];
  };
  
  
  ##  Conflicts and related PR:
  - We maybe have to merge these two branches together before going into main https://github.com/nix-community/gomod2nix/pull/243. They spot the same topic: private dependencies management.