### PR TITLE
Use pelletier/go-toml for multiline cachePackages output

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,8 +3,8 @@ module github.com/nix-community/gomod2nix
 go 1.24.0
 
 require (
-	github.com/BurntSushi/toml v1.6.0
 	github.com/nix-community/go-nix v0.0.0-20220612195009-5f5614f7ca47
+	github.com/pelletier/go-toml/v2 v2.2.4
 	github.com/sirupsen/logrus v1.9.4
 	github.com/spf13/cobra v1.10.1
 	golang.org/x/mod v0.32.0

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,5 @@
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
-github.com/BurntSushi/toml v1.6.0 h1:dRaEfpa2VI55EwlIW72hMRHdWouJeRF7TPYhI+AUQjk=
-github.com/BurntSushi/toml v1.6.0/go.mod h1:ukJfTF/6rtPPRCnwkur4qwRxa8vTRFBF0uk2lLoLwho=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
 github.com/alecthomas/kong v0.5.0/go.mod h1:uzxf/HUh0tj43x1AyJROl3JT7SgsZ5m+icOv1csRhc0=
 github.com/alecthomas/repr v0.0.0-20210801044451-80ca428c5142/go.mod h1:2kn6fqh/zIyPLmm3ugklbEi5hg5wS435eygvNfaDQL8=
@@ -49,6 +47,8 @@ github.com/mitchellh/mapstructure v1.1.2/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh
 github.com/nix-community/go-nix v0.0.0-20220612195009-5f5614f7ca47 h1:K270nNzKXBOJjEtPe91yAN+7NqMqgDt/D2gR5OCotxg=
 github.com/nix-community/go-nix v0.0.0-20220612195009-5f5614f7ca47/go.mod h1:eE1NFc/GHPnxAhTTuxIfB6JSvRQdMVQCMQqRrGRWWfQ=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
+github.com/pelletier/go-toml/v2 v2.2.4 h1:mye9XuhQ6gvn5h28+VilKrrPoQVanw5PMw/TB0t5Ec4=
+github.com/pelletier/go-toml/v2 v2.2.4/go.mod h1:2gIqNv+qfxSVS7cM2xJQKtLSTLUE9V8t9Stt+h56mCY=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=

--- a/gomod2nix.toml
+++ b/gomod2nix.toml
@@ -1,30 +1,38 @@
 schema = 3
 
 [mod]
-  [mod."github.com/BurntSushi/toml"]
-    version = "v1.6.0"
-    hash = "sha256-ptdUJvuc21ixeLt+M5way/na3aCnCO4MYHWulWp8NEY="
-  [mod."github.com/inconshreveable/mousetrap"]
-    version = "v1.1.0"
-    hash = "sha256-XWlYH0c8IcxAwQTnIi6WYqq44nOKUylSWxWO/vi+8pE="
-  [mod."github.com/nix-community/go-nix"]
-    version = "v0.0.0-20220612195009-5f5614f7ca47"
-    hash = "sha256-eBPzib8STUZnDpLFpWZz+F00thbp1P/98oiEE/XWE+M="
-  [mod."github.com/sirupsen/logrus"]
-    version = "v1.9.4"
-    hash = "sha256-ltRvmtM3XTCAFwY0IesfRqYIivyXPPuvkFjL4ARh1wg="
-  [mod."github.com/spf13/cobra"]
-    version = "v1.10.1"
-    hash = "sha256-OP6wdqk4dvBD8U5aicTkySHZ2s0LWnBo2TST2SmgcpM="
-  [mod."github.com/spf13/pflag"]
-    version = "v1.0.9"
-    hash = "sha256-YAjyYpq5BXCosVJtvYLWFG1t4gma2ylzc7ILLoj/hD8="
-  [mod."golang.org/x/mod"]
-    version = "v0.32.0"
-    hash = "sha256-4gbgIqTOo0vcYV3l4MIwmT/h8H9PXmcfrJ3z4B26Zl0="
-  [mod."golang.org/x/sys"]
-    version = "v0.14.0"
-    hash = "sha256-ReIRQmONicRW9idzGVPCBx5TTcKacmQTF1vPC3L4SxY="
-  [mod."golang.org/x/tools/go/vcs"]
-    version = "v0.1.0-deprecated"
-    hash = "sha256-57YB10tiRsVSRvJqKYST+iON6yZYGL7eRSzrFcImC8Y="
+[mod.'github.com/inconshreveable/mousetrap']
+version = 'v1.1.0'
+hash = 'sha256-XWlYH0c8IcxAwQTnIi6WYqq44nOKUylSWxWO/vi+8pE='
+
+[mod.'github.com/nix-community/go-nix']
+version = 'v0.0.0-20220612195009-5f5614f7ca47'
+hash = 'sha256-eBPzib8STUZnDpLFpWZz+F00thbp1P/98oiEE/XWE+M='
+
+[mod.'github.com/pelletier/go-toml/v2']
+version = 'v2.2.4'
+hash = 'sha256-8qQIPldbsS5RO8v/FW/se3ZsAyvLzexiivzJCbGRg2Q='
+
+[mod.'github.com/sirupsen/logrus']
+version = 'v1.9.4'
+hash = 'sha256-ltRvmtM3XTCAFwY0IesfRqYIivyXPPuvkFjL4ARh1wg='
+
+[mod.'github.com/spf13/cobra']
+version = 'v1.10.1'
+hash = 'sha256-OP6wdqk4dvBD8U5aicTkySHZ2s0LWnBo2TST2SmgcpM='
+
+[mod.'github.com/spf13/pflag']
+version = 'v1.0.9'
+hash = 'sha256-YAjyYpq5BXCosVJtvYLWFG1t4gma2ylzc7ILLoj/hD8='
+
+[mod.'golang.org/x/mod']
+version = 'v0.32.0'
+hash = 'sha256-4gbgIqTOo0vcYV3l4MIwmT/h8H9PXmcfrJ3z4B26Zl0='
+
+[mod.'golang.org/x/sys']
+version = 'v0.14.0'
+hash = 'sha256-ReIRQmONicRW9idzGVPCBx5TTcKacmQTF1vPC3L4SxY='
+
+[mod.'golang.org/x/tools/go/vcs']
+version = 'v0.1.0-deprecated'
+hash = 'sha256-57YB10tiRsVSRvJqKYST+iON6yZYGL7eRSzrFcImC8Y='

--- a/gomod2nix.toml
+++ b/gomod2nix.toml
@@ -1,38 +1,38 @@
 schema = 3
 
 [mod]
-[mod.'github.com/inconshreveable/mousetrap']
-version = 'v1.1.0'
-hash = 'sha256-XWlYH0c8IcxAwQTnIi6WYqq44nOKUylSWxWO/vi+8pE='
+  [mod.'github.com/inconshreveable/mousetrap']
+    version = 'v1.1.0'
+    hash = 'sha256-XWlYH0c8IcxAwQTnIi6WYqq44nOKUylSWxWO/vi+8pE='
 
-[mod.'github.com/nix-community/go-nix']
-version = 'v0.0.0-20220612195009-5f5614f7ca47'
-hash = 'sha256-eBPzib8STUZnDpLFpWZz+F00thbp1P/98oiEE/XWE+M='
+  [mod.'github.com/nix-community/go-nix']
+    version = 'v0.0.0-20220612195009-5f5614f7ca47'
+    hash = 'sha256-eBPzib8STUZnDpLFpWZz+F00thbp1P/98oiEE/XWE+M='
 
-[mod.'github.com/pelletier/go-toml/v2']
-version = 'v2.2.4'
-hash = 'sha256-8qQIPldbsS5RO8v/FW/se3ZsAyvLzexiivzJCbGRg2Q='
+  [mod.'github.com/pelletier/go-toml/v2']
+    version = 'v2.2.4'
+    hash = 'sha256-8qQIPldbsS5RO8v/FW/se3ZsAyvLzexiivzJCbGRg2Q='
 
-[mod.'github.com/sirupsen/logrus']
-version = 'v1.9.4'
-hash = 'sha256-ltRvmtM3XTCAFwY0IesfRqYIivyXPPuvkFjL4ARh1wg='
+  [mod.'github.com/sirupsen/logrus']
+    version = 'v1.9.4'
+    hash = 'sha256-ltRvmtM3XTCAFwY0IesfRqYIivyXPPuvkFjL4ARh1wg='
 
-[mod.'github.com/spf13/cobra']
-version = 'v1.10.1'
-hash = 'sha256-OP6wdqk4dvBD8U5aicTkySHZ2s0LWnBo2TST2SmgcpM='
+  [mod.'github.com/spf13/cobra']
+    version = 'v1.10.1'
+    hash = 'sha256-OP6wdqk4dvBD8U5aicTkySHZ2s0LWnBo2TST2SmgcpM='
 
-[mod.'github.com/spf13/pflag']
-version = 'v1.0.9'
-hash = 'sha256-YAjyYpq5BXCosVJtvYLWFG1t4gma2ylzc7ILLoj/hD8='
+  [mod.'github.com/spf13/pflag']
+    version = 'v1.0.9'
+    hash = 'sha256-YAjyYpq5BXCosVJtvYLWFG1t4gma2ylzc7ILLoj/hD8='
 
-[mod.'golang.org/x/mod']
-version = 'v0.32.0'
-hash = 'sha256-4gbgIqTOo0vcYV3l4MIwmT/h8H9PXmcfrJ3z4B26Zl0='
+  [mod.'golang.org/x/mod']
+    version = 'v0.32.0'
+    hash = 'sha256-4gbgIqTOo0vcYV3l4MIwmT/h8H9PXmcfrJ3z4B26Zl0='
 
-[mod.'golang.org/x/sys']
-version = 'v0.14.0'
-hash = 'sha256-ReIRQmONicRW9idzGVPCBx5TTcKacmQTF1vPC3L4SxY='
+  [mod.'golang.org/x/sys']
+    version = 'v0.14.0'
+    hash = 'sha256-ReIRQmONicRW9idzGVPCBx5TTcKacmQTF1vPC3L4SxY='
 
-[mod.'golang.org/x/tools/go/vcs']
-version = 'v0.1.0-deprecated'
-hash = 'sha256-57YB10tiRsVSRvJqKYST+iON6yZYGL7eRSzrFcImC8Y='
+  [mod.'golang.org/x/tools/go/vcs']
+    version = 'v0.1.0-deprecated'
+    hash = 'sha256-57YB10tiRsVSRvJqKYST+iON6yZYGL7eRSzrFcImC8Y='

--- a/internal/schema/schema.go
+++ b/internal/schema/schema.go
@@ -5,7 +5,7 @@ import (
 	"bytes"
 	"os"
 
-	"github.com/BurntSushi/toml"
+	"github.com/pelletier/go-toml/v2"
 )
 
 const SchemaVersion = 3
@@ -28,7 +28,7 @@ type Output struct {
 	GoPackagePath string `toml:"goPackagePath,omitempty"`
 
 	// List of packages to pre-compile in build cache for faster builds
-	CachePackages []string `toml:"cachePackages,omitempty"`
+	CachePackages []string `toml:"cachePackages,multiline,omitempty"`
 }
 
 func Marshal(pkgs []*Package, goPackagePath string, subPackages []string, cachePackages []string) ([]byte, error) {
@@ -67,8 +67,7 @@ func ReadCache(filePath string) map[string]*Package {
 	}
 
 	var output Output
-	_, err = toml.Decode(string(b), &output)
-	if err != nil {
+	if err := toml.Unmarshal(b, &output); err != nil {
 		return ret
 	}
 

--- a/internal/schema/schema.go
+++ b/internal/schema/schema.go
@@ -46,6 +46,7 @@ func Marshal(pkgs []*Package, goPackagePath string, subPackages []string, cacheP
 
 	var buf bytes.Buffer
 	e := toml.NewEncoder(&buf)
+	e.SetIndentTables(true)
 	err := e.Encode(out)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Fixes #252

The `cachePackages` array can grow large for projects with many dependencies. When formatted as a single line, diffs become difficult to review - a single package addition or removal rewrites the entire line.

This PR switches from BurntSushi/toml to pelletier/go-toml v2, which supports a `multiline` struct tag. The cachePackages field now renders with one package per line:

```toml
cachePackages = [
  'cel.dev/expr',
  'cloud.google.com/go/compute/metadata',
  'dario.cat/mergo',
]
```

The new library also uses single quotes and removes table indentation, which affects gomod2nix.toml formatting but remains valid TOML. Existing files will be reformatted on the next `gomod2nix` run.