### PR TITLE
Fix cross-compilation

### DIFF
--- a/builder/default.nix
+++ b/builder/default.nix
@@ -24,10 +24,8 @@ let
     inherit
       lib
       makeSetupHook
-      rsync
+      buildPackages
       stdenv
-      gnutar
-      zstd
       ;
   };
 
@@ -200,7 +198,6 @@ let
         goConfigHook
         gnutar
         zstd
-        # goConfigHook
       ]
       ++ nativeBuildInputs;
 

--- a/builder/hooks/default.nix
+++ b/builder/hooks/default.nix
@@ -1,17 +1,16 @@
 {
   lib,
   makeSetupHook,
-  rsync,
+  buildPackages,
   stdenv,
-  gnutar,
-  zstd,
 }:
 {
   goConfigHook = makeSetupHook {
     name = "goConfigHook";
-    # propagatedBuildInputs = [ rsync gnutar zstd ];
     substitutions = {
-      inherit rsync gnutar zstd;
+      rsync = lib.getExe buildPackages.rsync;
+      tar = lib.getExe buildPackages.gnutar;
+      zstd = lib.getExe buildPackages.zstd;
     };
   } ./go-config-hook.sh;
 

--- a/builder/hooks/go-config-hook.sh
+++ b/builder/hooks/go-config-hook.sh
@@ -66,7 +66,7 @@ goConfigHook() {
         if [ -n "${goVendorDir}" ]; then
             echo "Setting up vendor directory from ${goVendorDir}"
             rm -rf vendor
-            @rsync@/bin/rsync -a -K --ignore-errors "${goVendorDir}"/ vendor
+            @rsync@ -a -K --ignore-errors "${goVendorDir}"/ vendor
         fi
     fi
 
@@ -75,7 +75,7 @@ goConfigHook() {
         if [ -n "${goCacheDir}" ] && [ -f "${goCacheDir}/cache.tar.zst" ]; then
             echo "Restoring Go build cache from ${goCacheDir}/cache.tar.zst"
             mkdir -p "$GOCACHE"
-            @zstd@/bin/zstd -d -c "${goCacheDir}/cache.tar.zst" | @gnutar@/bin/tar -xf - -C "$GOCACHE"
+            @zstd@ -d -c "${goCacheDir}/cache.tar.zst" | @tar@ -xf - -C "$GOCACHE"
             chmod -R +w "$GOCACHE"
         fi
     fi


### PR DESCRIPTION
#231 moves some native build inputs into a setup hook which doesn't get spliced the same was as normal inputs. This uses `buildPackages` to get the build platform package set.

I've tried using `propagatedNativeBuildInputs` but it doesn't seem to work because it's part of a setup hook. 

Fixes #251 