### PR TITLE
Fix go.mod resolution inside go cache derivation

### DIFF
--- a/builder/default.nix
+++ b/builder/default.nix
@@ -442,10 +442,11 @@ let
 
       # Filter source to only dependency files for cache derivation
       # Use fetched source when building from goPackagePath
+      # When pwd is set but doesn't contain go.mod (goMod == null), use src instead
       depFilesSrc =
         if defaultPackage != "" then
           vendorEnv.passthru.sources.${defaultPackage}
-        else if pwd != null then
+        else if goMod != null then
           pwd
         else
           src;


### PR DESCRIPTION
Fixes #254 

`goMod` here is only valid if `pwd` contains a `go.mod` file. If it doesn't, falling back to `src` is a safer bet.